### PR TITLE
Properly parse PLMN and respect suppTA passed by user

### DIFF
--- a/TestCntlrApp/src/enbApp/nb.c
+++ b/TestCntlrApp/src/enbApp/nb.c
@@ -725,6 +725,8 @@ NbConfigReq   *cfg
    smCfgCb.s1SetupTmrVal       = cfg->s1SetupTmr;
    /* get the plmn-id */
    plmnLen = strlen((S8*)cfg->plmnId);
+   /* limit strlen as struct doesnt guarantee a null char after the str */
+   plmnLen = plmnLen > 6 ? 6 : plmnLen;
    plmnVal = atoi((S8*)cfg->plmnId);
 
    NB_GET_PLMN(tmpPlmn,plmnLen,plmnVal)

--- a/TestCntlrApp/src/enbApp/nb.c
+++ b/TestCntlrApp/src/enbApp/nb.c
@@ -724,9 +724,7 @@ NbConfigReq   *cfg
    smCfgCb.maxExpires          = cfg->maxExpires;
    smCfgCb.s1SetupTmrVal       = cfg->s1SetupTmr;
    /* get the plmn-id */
-   plmnLen = strlen((S8*)cfg->plmnId);
-   /* limit strlen as struct doesnt guarantee a null char after the str */
-   plmnLen = plmnLen > 6 ? 6 : plmnLen;
+   plmnLen = strnlen((S8*)cfg->plmnId, NBT_MAX_PLMN_ID);
    plmnVal = atoi((S8*)cfg->plmnId);
 
    NB_GET_PLMN(tmpPlmn,plmnLen,plmnVal)

--- a/TestCntlrApp/src/enbApp/nb.c
+++ b/TestCntlrApp/src/enbApp/nb.c
@@ -713,12 +713,14 @@ NbConfigReq   *cfg
    smCfgCb.cellId              = cfg->cellId;
    smCfgCb.trackAreaCode       = cfg->tac;
    smCfgCb.enbIpAddr           = cfg->enbIpAddr;
-   cmMemset(smCfgCb.enbName,0,NB_ENB_NAME);
-   if(strlen((S8*)cfg->enbName) < NB_ENB_NAME)
-   {
-      cmMemcpy(smCfgCb.enbName,cfg->enbName,strlen((S8*)cfg->enbName));
-      smCfgCb.enbNameLen            = strlen((S8*)cfg->enbName);
-   }
+
+   /* initialize entire enbName buffer to zero */
+   cmMemset(smCfgCb.enbName, 0, NB_ENB_NAME);
+
+   /* fetch length of enbName and copy to smCfgCb */
+   smCfgCb.enbNameLen = strnlen((S8*)cfg->enbName, NB_ENB_NAME);
+   cmMemcpy(smCfgCb.enbName, cfg->enbName, smCfgCb.enbNameLen);
+
    smCfgCb.sctpIpAddr          = cfg->sctpIpAddr;
    smCfgCb.inactvTmrVal        = cfg->inactvTmrVal;
    smCfgCb.maxExpires          = cfg->maxExpires;

--- a/TestCntlrApp/src/enbApp/nb_s1ap_hndlr.c
+++ b/TestCntlrApp/src/enbApp/nb_s1ap_hndlr.c
@@ -643,14 +643,8 @@ PRIVATE S16 nbBldS1SetupReq
       {
          tACItem = &ie->value.u.sztSuppTAs.member[taIdx];
          nbFillTknU8(&(tACItem->pres), PRSNT_NODEF);
-
-         #ifdef MULTI_ENB_SUPPORT
-         nbSztFillTAC(enbCb->tac, setupReqPdu,
-                      &tACItem->tAC);
-         #else
          nbSztFillTAC(smCfgCb.suppTAs.suppTA[taIdx].tac, setupReqPdu,
                       &tACItem->tAC);
-         #endif
          numComp = smCfgCb.suppTAs.suppTA[taIdx].bPlmnList.numBPlmns;
          /* Allocate memory for broadcast PLMNs */
          if ((cmGetMem(setupReqPdu, numComp * sizeof(SztBPLMNs),
@@ -663,15 +657,9 @@ PRIVATE S16 nbBldS1SetupReq
          nbFillTknU16(&(tACItem->broadcastPLMNs.noComp), numComp);
          for (idx = 0; idx < numComp; idx++)
          {
-         #ifdef MULTI_ENB_SUPPORT
-            nbSztFillPLMNId(setupReqPdu,
-                           &(enbCb->plmnId),
-                           &(tACItem->broadcastPLMNs.member[idx]));
-         #else
             nbSztFillPLMNId(setupReqPdu,
                            &(smCfgCb.suppTAs.suppTA[taIdx].bPlmnList.plmnIds[idx]),
                            &(tACItem->broadcastPLMNs.member[idx]));
-         #endif
          }
       }
       ieIdx++;

--- a/TestCntlrApp/src/tfwApp/fw_api_int.c
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.c
@@ -1326,20 +1326,20 @@ PUBLIC S16 handlEnbConfig(FwNbConfigReq_t *data)
 
    if (data->enbName_pr.pres  == TRUE)
    {
-      strcpy((S8*)msgReq->t.configReq.enbName, (S8*)data->enbName_pr.enb_name);
+      strncpy((S8*)msgReq->t.configReq.enbName, (S8*)data->enbName_pr.enb_name, MAX_ENB_NAME_LEN);
    }
    else
    {
-      strcpy((S8*)msgReq->t.configReq.enbName, (S8*)fwCb->nbAppCfgCb.enbName);
+      strncpy((S8*)msgReq->t.configReq.enbName, (S8*)fwCb->nbAppCfgCb.enbName, MAX_ENB_NAME_LEN);
    }
 
    if (data->plmnId_pr.pres  == TRUE)
    {
-      strcpy((S8*)msgReq->t.configReq.plmnId, (S8*)data->plmnId_pr.plmn_id);
+      strncpy((S8*)msgReq->t.configReq.plmnId, (S8*)data->plmnId_pr.plmn_id, MAX_PLMN_ID);
    }
    else
    {
-      strcpy((S8*)msgReq->t.configReq.plmnId, (S8*)fwCb->nbAppCfgCb.plmnId);
+      strncpy((S8*)msgReq->t.configReq.plmnId, (S8*)fwCb->nbAppCfgCb.plmnId, MAX_PLMN_ID);
    }
 
    if (data->heratbeatInterval_pr.pres  == TRUE)


### PR DESCRIPTION
Signed-off-by: Josiah White <me@josiahwhite.io>

## Title
Properly parse PLMN and respect suppTA passed by user

## Summary

- Truncates the size of the PLMN id as returned by `strlen`
- Removes ifdefs in the `suppTA` parameter handling to allow the user-specified TA to be sent in the S1-Setup request
- Changed some string copies from `strcpy` to `strncpy` with a size limit.

## Test plan
Verified with sanity
