### PR TITLE
Fix handling of ipv4v6 transport layer address

### DIFF
--- a/TestCntlrApp/src/enbApp/nb_s1ap_hndlr.c
+++ b/TestCntlrApp/src/enbApp/nb_s1ap_hndlr.c
@@ -2952,7 +2952,22 @@ PUBLIC S16 nbGetErabInfoFrmErabSetup(NbUeCb *ueCb,
             {
                /* This means both IPv4 and IPv6 addresses are present. We are */
                /* yet to support this option                                  */
-               // TODO: Add ipv4v6 support
+               // TODO: Add ipv4v6 support. For now, copy ipv4 addr only
+               tunInfo->sgwAddr.type = CM_TPTADDR_IPV4;
+               tunInfo->sgwAddr.u.ipv4TptAddr.port = NB_DFLT_EGTP_PORT;
+
+               // copy 4bytes into the U32
+               shiftBits = erabItem->transportLyrAddr.len / 8;
+               addrMask = 0xFF000000;
+               for(indx = 0; indx < 4; indx++)
+               {
+                  shiftBits--;
+                  tunInfo->sgwAddr.u.ipv4TptAddr.address |=
+                     ((U32)(erabItem->transportLyrAddr.val[indx]
+                        << (8 * shiftBits)) & addrMask);
+                  addrMask = addrMask >> 8;
+               }
+
                break;
             }
       }
@@ -3077,13 +3092,26 @@ PUBLIC S16 nbGetErabInfoFrmIntCnxt
                }
                break;
             }
-         default:
-            {
+         default: {
                /* This means both IPv4 and IPv6 addresses are present. We are */
                /* yet to support this option                                  */
-              // TODO: Add ipv4v6 support
-              break;
-            }
+              // TODO: Add ipv4v6 support. For now, copy ipv4 addr only
+              tunInfo->sgwAddr.type = CM_TPTADDR_IPV4;
+              tunInfo->sgwAddr.u.ipv4TptAddr.\
+                 port = NB_DFLT_EGTP_PORT;
+
+              // copy 4bytes into the U32
+              shiftBits = erabItem->transportLyrAddr.len / 8;
+              addrMask = 0xFF000000;
+              for(indx = 0; indx < 4; indx++) {
+                shiftBits--;
+                tunInfo->sgwAddr.u.ipv4TptAddr.address |=
+                   ((U32)(erabItem->transportLyrAddr.val[indx]
+                      << (8 * shiftBits)) & addrMask);
+                addrMask = addrMask >> 8;
+              }
+             break;
+           }
       }
       if (ROK != cmHashListInsert(&(ueCb->tunnInfo),(PTR)tunInfo,
                (U8 *) &tunInfo->bearerId,sizeof(U32)))


### PR DESCRIPTION
Signed-off-by: Pruthvi Hebbani <pruthvi.hebbani@radisys.com>

Fix handling of ipv4v6 transport layer address

## Summary
ipv4v6 transport layer address received in ICS request was not getting stored which is needed for handling data. Fixed the issue

## Test plan
Verified integ tests