### PR TITLE
stropts.h is no longer included

### DIFF
--- a/TestCntlrApp/src/cm/cm_os.c
+++ b/TestCntlrApp/src/cm/cm_os.c
@@ -72,7 +72,6 @@
 /* cm_os_c_001.main_12: Excluding header files for 4GMX */
 #ifndef SS_4GMX_LCORE
 #include <termios.h>
-#include <stropts.h>
 #include <poll.h>
 #endif
 #endif /* DEF_NTSSLIB */

--- a/TestCntlrApp/src/fw_cm/cm_os.c
+++ b/TestCntlrApp/src/fw_cm/cm_os.c
@@ -77,7 +77,6 @@
 /* cm_os_c_001.main_12: Excluding header files for 4GMX */
 #ifndef SS_4GMX_LCORE
 #include <termios.h>
-#include <stropts.h>
 #include <poll.h>
 #endif
 #endif /* DEF_NTSSLIB */


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

## Title
PR removes the c++-lib stropts.h 

## Summary
`stropts.h` is a c++ library that is not supported anymore by current linux distributions. This creates a problem i.e. for upgrading the magma_test vm to Ubuntu 20.04, see magma/magma#4519
Upon first code review and testing, this lib is apparently not needed for the integration tests. Can we drop it? 

## Test plan
- S1AP Integration tests for magma
The results for both `make -i precommit` and `make -i integ_test` in magma are identical with and without the change.
